### PR TITLE
add some basic test cases for http example

### DIFF
--- a/http/package.json
+++ b/http/package.json
@@ -6,6 +6,7 @@
     "build": "tsc --build ./tsconfig.json",
     "build.watch": "tsc --build --watch ./tsconfig.json",
     "schedule-workflow": "node ./lib/starter",
+    "test": "ts-mocha ./test/*.test.ts",
     "worker": "node ./lib/worker"
   },
   "dependencies": {
@@ -13,6 +14,10 @@
     "temporalio": "0.4.2"
   },
   "devDependencies": {
+    "@types/mocha": "8.x",
+    "mocha": "8.x",
+    "sinon": "^11.1.2",
+    "ts-mocha": "^8.0.0",
     "typescript": "^4.2.2",
     "@tsconfig/node14": "^1.0.0"
   }

--- a/http/src/starter/index.ts
+++ b/http/src/starter/index.ts
@@ -5,7 +5,7 @@ async function run() {
   const connection = new Connection();
   const client = new WorkflowClient(connection.service);
 
-  const workflow = client.createWorkflowHandle(example, { taskQueue: 'tutorial20210915' });
+  const workflow = client.createWorkflowHandle(example, { taskQueue: 'tutorial' });
 
   const result = await workflow.execute();
   console.log(result); // 'The answer is 42'

--- a/http/src/worker.ts
+++ b/http/src/worker.ts
@@ -5,7 +5,7 @@ run().catch(err => console.log(err));
 async function run() {
   const worker = await Worker.create({
     workDir: __dirname,
-    taskQueue: 'tutorial20210915'
+    taskQueue: 'tutorial'
   });
 
   await worker.run();

--- a/http/test/workflow.test.ts
+++ b/http/test/workflow.test.ts
@@ -1,0 +1,52 @@
+import { Connection, WorkflowClient } from '@temporalio/client';
+import { Worker, DefaultLogger } from '@temporalio/worker';
+import { describe, before, after, it } from 'mocha';
+import { example } from '../lib/workflows';
+import assert from 'assert';
+import axios from 'axios';
+import sinon from 'sinon';
+
+describe('example workflow', function() {
+  let worker = null;
+  let runPromise = null;
+
+  before(async function() {
+    this.timeout(10000);
+    worker = await Worker.create({
+      workDir: `${__dirname}/../lib`,
+      taskQueue: 'tutorial20210916',
+      logger: new DefaultLogger('ERROR'),
+    });
+
+    runPromise = worker.run();
+  });
+
+  after(async function() {
+    worker.shutdown();
+    await runPromise;
+  });
+
+  it('returns correct result', async function() {
+    const connection = new Connection();
+    const client = new WorkflowClient(connection.service);
+
+    const workflow = client.createWorkflowHandle(example, { taskQueue: 'tutorial20210916' });
+
+    const result = await workflow.execute();
+    assert.equal(result, 'The answer is 42');
+  });
+
+  it('handles errors', async function() {
+    this.timeout(5000);
+    const connection = new Connection();
+    const client = new WorkflowClient(connection.service);
+
+    const workflow = client.createWorkflowHandle(example, { taskQueue: 'tutorial20210916' });
+
+    //sinon.stub(axios, 'get').callsFake(() => Promise.resolve({ data: { args: { answer: 42 } } }));
+    sinon.stub(axios, 'get').callsFake(() => Promise.reject(new Error('42')));
+
+    // This call hangs:
+    const result = await workflow.execute();
+  });
+});


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

I'm working on adding some integration tests - I took a look and it looks like you should be able to stub out some activity logic using sinon. But I ran into an issue: when axios is stubbed out to return an error `sinon.stub(axios, 'get').callsFake(() => Promise.reject(new Error('42')));`, the `workflow.execute()` call hangs, and the error never bubbles up to the Workflow. Any ideas @bergundy ?

I borrowed some test patterns from here: https://github.com/temporalio/sdk-node/blob/main/packages/test/src/test-integration.ts

## Why?
<!-- Tell your future self why have you made these changes -->

Right now we don't have a full testing solution that handles stubbing activities and advancing time, but I wanted to see if I could use sinon to get a scrappy approach working.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
