### PR TITLE
rename `workflow` -> `handle` in starter / `execute-workflow.ts`

### DIFF
--- a/activities-examples/src/starter/index.ts
+++ b/activities-examples/src/starter/index.ts
@@ -1,13 +1,13 @@
 import { Connection, WorkflowClient } from '@temporalio/client';
 import { example } from '../workflows';
 
-async function run() {
+async function run(): Promise<void> {
   const connection = new Connection();
   const client = new WorkflowClient(connection.service);
 
-  const workflow = client.createWorkflowHandle(example, { taskQueue: 'tutorial' });
+  const handle = client.createWorkflowHandle(example, { taskQueue: 'tutorial' });
 
-  const result = await workflow.execute();
+  const result = await handle.execute();
   console.log(result); // 'The answer is 42'
 }
 

--- a/cancellation/src/starter/index.ts
+++ b/cancellation/src/starter/index.ts
@@ -5,12 +5,12 @@ async function run() {
   const connection = new Connection();
   const client = new WorkflowClient(connection.service);
 
-  const workflow = client.createWorkflowHandle(example, { taskQueue: 'tutorial' });
+  const handle = client.createWorkflowHandle(example, { taskQueue: 'tutorial' });
 
-  await workflow.start();
+  await handle.start();
 
   await new Promise((resolve) => setTimeout(resolve, 100));
-  await workflow.cancel();
+  await handle.cancel();
   console.log('Cancelled workflow successfully');
 }
 

--- a/expense/src/starter/approve.ts
+++ b/expense/src/starter/approve.ts
@@ -5,16 +5,16 @@ import { v4 } from 'uuid';
 async function run() {
   const connection = new Connection();
   const client = new WorkflowClient(connection.service);
-  const workflow = client.createWorkflowHandle(expense, { taskQueue: 'tutorial' });
+  const handle = client.createWorkflowHandle(expense, { taskQueue: 'tutorial' });
 
   const expenseId = v4();
 
-  await workflow.start(expenseId);
+  await handle.start(expenseId);
 
   await new Promise((resolve) => setTimeout(resolve, 50));
-  await workflow.signal.approve();
+  await handle.signal.approve();
 
-  console.log('Done:', await workflow.result()); // Done: { status: 'COMPLETED' }
+  console.log('Done:', await handle.result()); // Done: { status: 'COMPLETED' }
 }
 run().catch((err) => {
   console.error(err);

--- a/expense/src/starter/timeout.ts
+++ b/expense/src/starter/timeout.ts
@@ -5,12 +5,12 @@ import { v4 } from 'uuid';
 async function run() {
   const connection = new Connection();
   const client = new WorkflowClient(connection.service);
-  const workflow = client.createWorkflowHandle(expense, { taskQueue: 'tutorial' });
+  const handle = client.createWorkflowHandle(expense, { taskQueue: 'tutorial' });
 
   const expenseId = v4();
 
   // Prints "Done: { status: 'TIMED_OUT' }" after approximately 1 second
-  console.log('Done:', await workflow.execute(expenseId, 1000));
+  console.log('Done:', await handle.execute(expenseId, 1000));
 }
 run().catch((err) => {
   console.error(err);

--- a/hello-world-mtls/package.json
+++ b/hello-world-mtls/package.json
@@ -10,7 +10,7 @@
     "workflow": "ts-node src/execute-workflow.ts"
   },
   "dependencies": {
-    "temporalio": "^0.4.1"
+    "temporalio": "0.4.1"
   },
   "devDependencies": {
     "@tsconfig/node16": "^1.0.0",

--- a/hello-world/src/starter/index.ts
+++ b/hello-world/src/starter/index.ts
@@ -10,8 +10,8 @@ async function run() {
   // via options passed the WorkflowClient constructor.
   const client = new WorkflowClient(connection.service);
   // Create a typed handle for the example Workflow.
-  const workflow = client.createWorkflowHandle(example, { taskQueue: 'tutorial' });
-  const result = await workflow.execute('Temporal');
+  const handle = client.createWorkflowHandle(example, { taskQueue: 'tutorial' });
+  const result = await handle.execute('Temporal');
   console.log(result); // Hello, Temporal!
 }
 

--- a/interceptors-opentelemetry/package.json
+++ b/interceptors-opentelemetry/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "@temporalio/interceptors-opentelemetry": "^0.1.2",
-    "temporalio": "^0.4.1"
+    "temporalio": "0.4.1"
   },
   "devDependencies": {
     "@tsconfig/node14": "^1.0.0",

--- a/progress/src/starter/index.ts
+++ b/progress/src/starter/index.ts
@@ -5,15 +5,15 @@ async function run() {
   const connection = new Connection();
   const client = new WorkflowClient(connection.service);
 
-  const workflow = client.createWorkflowHandle(progress, { taskQueue: 'tutorial' });
+  const handle = client.createWorkflowHandle(progress, { taskQueue: 'tutorial' });
 
-  await workflow.start();
+  await handle.start();
 
-  const val = await workflow.query.getProgress();
+  const val = await handle.query.getProgress();
   // Should print "10", may print another number depending on timing
   console.log(val);
 
-  const result = await workflow.result();
+  const result = await handle.result();
   console.log(result); // 100
 }
 

--- a/signals-queries/src/exec-workflow.ts
+++ b/signals-queries/src/exec-workflow.ts
@@ -1,7 +1,7 @@
 import { Connection, WorkflowClient } from '@temporalio/client';
 import { unblockOrCancel } from './workflows';
 
-async function run() {
+async function run(): Promise<void> {
   // Connect to localhost with default ConnectionOptions,
   // pass options to the Connection constructor to configure TLS and other settings.
   const connection = new Connection();
@@ -9,12 +9,12 @@ async function run() {
   // via options passed the WorkflowClient constructor.
   const client = new WorkflowClient(connection.service);
   // Create a typed handle for the example Workflow.
-  const workflow = client.createWorkflowHandle(unblockOrCancel, { taskQueue: 'tutorial' });
-  await workflow.start();
-  console.log(await workflow.query.isBlocked()); // true
-  await workflow.signal.unblock();
-  await workflow.result();
-  console.log(await workflow.query.isBlocked()); // false
+  const handle = client.createWorkflowHandle(unblockOrCancel, { taskQueue: 'tutorial' });
+  await handle.start();
+  console.log(await handle.query.isBlocked()); // true
+  await handle.signal.unblock();
+  await handle.result();
+  console.log(await handle.query.isBlocked()); // false
 }
 
 run().catch((err) => {


### PR DESCRIPTION
<!--- Note to EXTERNAL Contributors -->
<!-- Thanks for opening a PR! 
If it is a significant code change, please **make sure there is an open issue** for this. 
We work best with you when we have accepted the idea first before you code. -->

<!--- For ALL Contributors 👇 -->

## What was changed
<!-- Describe what has changed in this PR -->

As per discussion in Slack, `workflow` is renamed to `handle` to be more consistent with `createWorkflowHandle()`

## Why?
<!-- Tell your future self why have you made these changes -->

Better nomenclature. `createWorkflowHandle()` returns a workflow handle, so better to call the variable `workflowHandle` or `handle` than `workflow`.

## Checklist
<!--- add/delete as needed --->

1. Closes <!-- add issue number here -->

2. How was this tested:
<!--- Please describe how you tested your changes/how we can test them -->

3. Any docs updates needed?
<!--- update README if applicable
      or point out where to update docs.temporal.io -->
