### PR TITLE
Use npm-run-all

### DIFF
--- a/ecommerce-one-click/nextjs/package.json
+++ b/ecommerce-one-click/nextjs/package.json
@@ -2,13 +2,13 @@
   "private": true,
   "name": "temporal-nextjs-oneclick",
   "scripts": {
-    "dev": "npm run temporal:build && npm run next:dev & npm run temporal:dev & npm run temporal:worker",
-    "next:dev": "next dev",
-    "temporal:dev": "tsc --build --watch ./temporal/tsconfig.json",
-    "build": "next build",
-    "temporal:build": "tsc --build ./temporal/tsconfig.json",
-    "start": "echo 'use npm run dev instead'",
-    "temporal:worker": "node ./temporal/lib/worker"
+    "dev": "npm-run-all -l build:temporal --parallel dev:temporal dev:next start:worker",
+    "dev:next": "next dev",
+    "dev:temporal": "tsc --build --watch ./temporal/tsconfig.json",
+    "build:next": "next build",
+    "build:temporal": "tsc --build ./temporal/tsconfig.json",
+    "start": "npm run dev",
+    "start:worker": "node ./temporal/lib/worker"
   },
   "dependencies": {
     "@headlessui/react": "^1.4.1",
@@ -25,6 +25,7 @@
   "devDependencies": {
     "@tsconfig/node16": "^1.0.2",
     "autoprefixer": "^10.2.6",
+    "npm-run-all": "^4.1.5",
     "postcss": "^8.3.5",
     "tailwindcss": "^2.2.4",
     "typescript": "^4.4.3"


### PR DESCRIPTION
In nextjs sample:
- Simplify `npm run dev` command, and allow user to stop all commands with Cmd-C (currently you have to `kill <pid>`)
- It appears from my cursory research that `command:scope` is more common for script naming. See for instance these examples:
https://stackoverflow.com/questions/47606101/what-is-colon-in-npm-script-names
https://github.com/mysticatea/npm-run-all/

@sw-yx 